### PR TITLE
add dockerignore to preventing copy node dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+**/node_modules


### PR DESCRIPTION
preventing error of building docker after installing node dependencies